### PR TITLE
Fix error message when storage chunk shape exceeds data shape

### DIFF
--- a/activestorage/active_tools.py
+++ b/activestorage/active_tools.py
@@ -321,7 +321,7 @@ def as_process_chunk(
 
     # store selected data in output
     if np.prod(tmp.shape) > np.prod(out.shape):
-        raise ValueError(f"Chunk shape {tmp.shape} exceeds permitted "
+        raise ValueError(f"Storage chunk shape {tmp.shape} exceeds permitted "
                          f"output data shape {out.shape}.")
     out[out_selection] = tmp
 

--- a/tests/unit/test_active_tools.py
+++ b/tests/unit/test_active_tools.py
@@ -140,7 +140,7 @@ def test_process_chunk_uncompressed_write_direct():
                                  fields=None,
                                  out_selection=out_selection,
                                  partial_read_decode=False)
-    assert str(exc.value) == "Chunk shape (2, 8) exceeds permitted output data shape (1, 8)."
+    assert str(exc.value) == "Storage chunk shape (2, 8) exceeds permitted output data shape (1, 8)."
 
 
 def test_process_chunk_compressed():


### PR DESCRIPTION
Pointed out in https://github.com/valeriupredoi/PyActiveStorage/pull/39#discussion_r1015257731