### PR TITLE
Do not use masked numpy statistics

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -25,12 +25,12 @@ class Active:
         """Store reduction methods."""
         instance = super().__new__(cls)
         instance._methods = {
-            "min": np.ma.min,
-            "max": np.ma.max,
-            "sum": np.ma.sum,
+            "min": np.min,
+            "max": np.max,
+            "sum": np.sum,
             # For the unweighted mean we calulate the sum and divide
             # by the number of non-missing elements
-            "mean": np.ma.sum,
+            "mean": np.sum,
         }
         return instance
 

--- a/activestorage/storage.py
+++ b/activestorage/storage.py
@@ -43,13 +43,11 @@ def reduce_chunk(rfile, offset, size, compression, filters, missing, dtype, shap
     if method:
         if missing != (None, None, None, None):
             tmp = remove_missing(tmp, missing)
-            # we are using masked arrays here, so we have to undo that
-            # a vanilla implementation of remove_missing which found
-            # no valid data would have to do something like this too.
-            result = method(tmp)
-            return result, tmp.count()   
-        else:
+        # check on size of tmp; method(empty) returns nan
+        if tmp.any():
             return method(tmp), tmp.size
+        else:
+            return tmp, None
     else:
         return tmp, None
 
@@ -69,7 +67,10 @@ def remove_missing(data, missing):
     if valid_min:
         data = np.ma.masked_less(data, valid_min)
 
+    data = np.ma.compressed(data)
+
     return data
+
 
 def read_block(open_file, offset, size):
     """ Read <size> bytes from <open_file> at <offset>"""

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -56,9 +56,8 @@ def test_reduced_chunk_masked_data():
                          missing=(None, 999.0, None, None),
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
-                         method=np.ma.mean)
-    assert rc[0] == 249.45955882352942
-    assert rc[1] == 680
+                         method=np.mean)
+    np.testing.assert_array_equal(rc, (np.float32(249.459564), 680))
 
 
 def test_reduced_chunk_fully_masked_data_fill():
@@ -75,9 +74,9 @@ def test_reduced_chunk_fully_masked_data_fill():
                          missing=(None, 999.0, None, None),
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
-                         method=np.ma.mean)
-    assert rc[1] == 0
-    np.testing.assert_array_equal(rc[0], np.array([], dtype=np.float64))
+                         method=np.mean)
+    assert rc[0].size == 0
+    assert rc[1] is None
 
 
 def test_reduced_chunk_fully_masked_data_missing():
@@ -94,9 +93,9 @@ def test_reduced_chunk_fully_masked_data_missing():
                          missing=(999., None, None, None),
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
-                         method=np.ma.mean)
-    assert rc[1] == 0
-    np.testing.assert_array_equal(rc[0], np.array([], dtype=np.float64))
+                         method=np.mean)
+    assert rc[0].size == 0
+    assert rc[1] is None
 
 
 def test_reduced_chunk_fully_masked_data_vmin():
@@ -113,9 +112,9 @@ def test_reduced_chunk_fully_masked_data_vmin():
                          missing=(None, None, 1000., None),
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
-                         method=np.ma.mean)
-    assert rc[1] == 0
-    np.testing.assert_array_equal(rc[0], np.array([], dtype=np.float64))
+                         method=np.mean)
+    assert rc[0].size == 0
+    assert rc[1] is None
 
 
 def test_reduced_chunk_fully_masked_data_vmax():
@@ -132,6 +131,6 @@ def test_reduced_chunk_fully_masked_data_vmax():
                          missing=(None, None, None, 1.),
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
-                         method=np.ma.mean)
-    assert rc[1] == 0
-    np.testing.assert_array_equal(rc[0], np.array([], dtype=np.float64))
+                         method=np.mean)
+    assert rc[0].size == 0
+    assert rc[1] is None

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -57,6 +57,10 @@ def test_reduced_chunk_masked_data():
                          dtype="float32", shape=(62, 2, 3, 2),
                          order="C", chunk_selection=ch_sel,
                          method=np.mean)
+    # test the output dtype
+    np.testing.assert_raises(AssertionError,
+                             np.testing.assert_array_equal, rc, (249.459564, 680))
+    # test result with correct dtype
     np.testing.assert_array_equal(rc, (np.float32(249.459564), 680))
 
 


### PR DESCRIPTION
Here we go @davidhassell and @bnlawrence - two mentions here:

- the test we saw failing was doing so because a masked statistic would output a float64 dtype, even if the dtype in the input for the test was hardcoded as float32, it is now fixed by shoving a float32 result
- we have to be careful `tmp` is not fully empty (like in the test case), then `method(tmp)` returns a `nan` which is a valid number (well, not a number, but in its machine interpretation still a number) so I put a check on that