### PR TITLE
Pin zarr and change latest supported Python=3.11

### DIFF
--- a/.github/workflows/run-test-push.yml
+++ b/.github/workflows/run-test-push.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.10"]  # latest only
+        python-version: ["3.11"]  # latest only
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - pin_zarr
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - pin_zarr
   schedule:
     - cron: '0 0 * * *'  # nightly
 
@@ -12,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     name: Linux Python ${{ matrix.python-version }}
     steps:
@@ -40,7 +41,7 @@ jobs:
     runs-on: "macos-latest"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     name: OSX Python ${{ matrix.python-version }}
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,4 @@ dependencies:
   - pip !=21.3
   - pytest
   - xarray
-  - zarr
+  - zarr <=2.13.3  # github.com/valeriupredoi/PyActiveStorage/issues/62

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIREMENTS = {
         'netcdf4',
         'pytest',
         'xarray',
-        'zarr',
+        'zarr<=2.13.3', # github.com/valeriupredoi/PyActiveStorage/issues/62
         # for testing
         'pytest-cov>=2.10.1',
         'pytest-xdist',


### PR DESCRIPTION
Addresses (but doesn't klose it) #62 - plus, added bonus I had time to test with the latest Python=3.11 which we now support :partying_face: 