### PR TITLE
Pin Zarr >=2.13.6 so we use new FSStore objects (instead of KVStore)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix_Bryan_voodoo
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix_Bryan_voodoo
   schedule:
     - cron: '0 0 * * *'  # nightly
 

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -243,8 +243,12 @@ class Active:
         stripped_indexer = [(a, b, c) for a,b,c in indexer]
         drop_axes = indexer.drop_axes  # not sure what this does and why, yet.
 
-        # yes this next line is bordering on voodoo ... 
-        fsref = self.zds.chunk_store._mutable_mapping.fs.references
+        # yes this next line is bordering on voodoo ...
+        # this returns a nested dictionary with the full file FS reference
+        # ie all the gubbins: chunks, data structure, types, etc
+        # if using zarr<=2.13.3 call with _mutable_mapping ie
+        # fsref = self.zds.chunk_store._mutable_mapping.fs.references 
+        fsref = self.zds.chunk_store.fs.references
 
         return self._from_storage(stripped_indexer, drop_axes, out_shape,
                                   out_dtype, compressor, filters, missing, fsref)

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,6 @@ dependencies:
   - pip !=21.3
   - pytest
   - xarray
-  - zarr <=2.13.3  # github.com/valeriupredoi/PyActiveStorage/issues/62
+  # pin Zarr to avoid using old KVStore interface
+  # see github.com/zarr-developers/zarr-python/issues/1362
+  - zarr >=2.13.6  # KVStore to FSStore

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ REQUIREMENTS = {
         'netcdf4',
         'pytest',
         'xarray',
-        'zarr<=2.13.3', # github.com/valeriupredoi/PyActiveStorage/issues/62
+        # pin Zarr to use new FSStore instead of KVStore
+        'zarr>=2.13.3', # github.com/zarr-developers/zarr-python/issues/1362
         # for testing
         'pytest-cov>=2.10.1',
         'pytest-xdist',


### PR DESCRIPTION
Closes #62 #64 

@davidhassell and myself have agreed to pin Zarr to (alomost) latest so we don't use the older KVStore and hence the need to call a private function, see https://github.com/zarr-developers/zarr-python/issues/1362#issuecomment-1456479692

```
fsref = self.zds.chunk_store._mutable_mapping.fs.references
```
changes to
```
fsref = self.zds.chunk_store.fs.references
```

with newer Zarrs. Many thanks to @rabernat for sorting me out in https://github.com/zarr-developers/zarr-python/issues/1362