### PR TITLE
Fix test_missing to avoid duplicate tests

### DIFF
--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -38,7 +38,7 @@ def test_partially_missing_data(tmp_path):
 
 def test_missing(tmp_path):
     testfile = str(tmp_path / 'test_missing.nc')
-    r = dd.make_partially_missing_ncdata(testfile)
+    r = dd.make_missing_ncdata(testfile)
     _doit(testfile)
 
 def test_fillvalue(tmp_path):


### PR DESCRIPTION
test_missing and test_partially_missing_data in tests/test_missing.py
were previously identical.

This change switches test_missing to use the similarly named
make_missing_data function.

Fixes: #101
