### PR TITLE
Refactor test_harness.py to use native pytest

### DIFF
--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -12,88 +12,73 @@ from activestorage.dummy_data import make_vanilla_ncdata
 import utils
 
 
-class TestActive(unittest.TestCase):
-    """ 
-    Test basic functionality
+def create_test_dataset(tmp_path):
     """
+    Ensure there is test data
+    """
+    temp_file = str(tmp_path / 'test_bizarre.nc')
+    make_vanilla_ncdata(filename=temp_file)
+    test_file = utils.write_to_storage(temp_file)
+    if USE_S3:
+        os.remove(temp_file)
+    return test_file
 
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def setUp(self):
-        """ 
-        Ensure there is test data
-        """
-        self.temp_folder = tempfile.mkdtemp()
-        temp_file = os.path.join(self.temp_folder,
-                                     'test_bizarre.nc')
-        print(f"Test file is {temp_file}")
-        if not os.path.exists(temp_file):
-            make_vanilla_ncdata(filename=temp_file)
 
-        self.testfile = utils.write_to_storage(temp_file)
-        if USE_S3:
-            os.remove(temp_file)
+@pytest.mark.xfail(USE_S3, reason="descriptor 'flatten' for 'numpy.ndarray' objects doesn't apply to a 'memoryview' object")
+def test_read0(tmp_path):
+    """
+    Test a normal read slicing the data an interesting way, using version 0 (native interface)
+    """
+    test_file = create_test_dataset(tmp_path)
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active._version = 0
+    d = active[0:2,4:6,7:9]
+    nda = np.ndarray.flatten(d.data)
+    assert np.array_equal(nda,np.array([740.,840.,750.,850.,741.,841.,751.,851.]))
 
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def tearDown(self):
-        """Remove temp folder."""
-        shutil.rmtree(self.temp_folder)
-        
-    # @pytest.mark.xfail(USE_S3, reason="descriptor 'flatten' for 'numpy.ndarray' objects doesn't apply to a 'memoryview' object")
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def testRead0(self):
-        """ 
-        Test a normal read slicing the data an interesting way, using version 0 (native interface)
-        """
-        active = Active(self.testfile, 'data', utils.get_storage_type())
-        active._version = 0
-        d = active[0:2,4:6,7:9]
-        nda = np.ndarray.flatten(d.data)
-        assert np.array_equal(nda,np.array([740.,840.,750.,850.,741.,841.,751.,851.]))
+def test_read1(tmp_path):
+    """
+    Test a normal read slicing the data an interesting way, using version 1 (replicating native interface in our code)
+    """
+    test_file = create_test_dataset(tmp_path)
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active._version = 0
+    d0 = active[0:2,4:6,7:9]
 
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def testRead1(self):
-        """ 
-        Test a normal read slicing the data an interesting way, using version 1 (replicating native interface in our code)
-        """
-        active = Active(self.testfile, 'data', utils.get_storage_type())
-        active._version = 0
-        d0 = active[0:2,4:6,7:9]
-        
-        active = Active(self.testfile, 'data', utils.get_storage_type())
-        active._version = 1
-        d1 = active[0:2,4:6,7:9]
-        assert np.array_equal(d0,d1)
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active._version = 1
+    d1 = active[0:2,4:6,7:9]
+    assert np.array_equal(d0,d1)
 
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def testActive(self):
-        """ 
-        Shows what we expect an active example test to achieve and provides "the right answer"
-        """
-        active = Active(self.testfile, 'data', utils.get_storage_type())
-        active._version = 0
-        d = active[0:2,4:6,7:9]
-        mean_result = np.mean(d)
+def test_active(tmp_path):
+    """
+    Shows what we expect an active example test to achieve and provides "the right answer"
+    """
+    test_file = create_test_dataset(tmp_path)
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active._version = 0
+    d = active[0:2,4:6,7:9]
+    mean_result = np.mean(d)
 
-        active = Active(self.testfile, 'data', utils.get_storage_type())
-        active.method = "mean"
-        result2 = active[0:2,4:6,7:9]
-        self.assertEqual(mean_result, result2)
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active.method = "mean"
+    result2 = active[0:2,4:6,7:9]
+    assert mean_result == result2
 
-    @pytest.mark.skipif(USE_S3, reason="possible I/O race condition via self.testfile")
-    def testActiveComponents(self):
-        """
-        Shows what we expect an active example test to achieve and provides "the right answer" 
-        """
-        active = Active(self.testfile, "data", utils.get_storage_type())
-        active._version = 0
-        d = active[0:2, 4:6, 7:9]
-        mean_result = np.mean(d)
+def testActiveComponents(tmp_path):
+    """
+    Shows what we expect an active example test to achieve and provides "the right answer"
+    """
+    test_file = create_test_dataset(tmp_path)
+    active = Active(test_file, "data", utils.get_storage_type())
+    active._version = 0
+    d = active[0:2, 4:6, 7:9]
+    mean_result = np.mean(d)
 
-        active = Active(self.testfile, "data", utils.get_storage_type())
-        active._version = 2
-        active.method = "mean"
-        active.components = True
-        result2 = active[0:2, 4:6, 7:9]
-        print(result2)
-        self.assertEqual(mean_result, result2["sum"]/result2["n"])
-
+    active = Active(test_file, "data", utils.get_storage_type())
+    active._version = 2
+    active.method = "mean"
+    active.components = True
+    result2 = active[0:2, 4:6, 7:9]
+    print(result2)
+    assert mean_result == result2["sum"]/result2["n"]


### PR DESCRIPTION
It was written using the unittest style, and is thought to be causing issues for the S3 tests.

Refactor into pytest style, and remove skip decorators for S3.

Closes: #116
