### PR TITLE
Rename S3 Active Storage to Reductionist

### DIFF
--- a/.github/workflows/test_s3_minio.yml
+++ b/.github/workflows/test_s3_minio.yml
@@ -1,4 +1,4 @@
-# adapted GA workflow from https://github.com/stackhpc/s3-active-storage-rs
+# adapted GA workflow from https://github.com/stackhpc/reductionist-rs
 ---
 name: S3/Minio Test
 
@@ -47,8 +47,8 @@ jobs:
           until curl -if http://localhost:9001; do
             sleep 1;
           done
-      - name: Run S3ActiveStorage container
-        run: docker run -it --detach --rm --net=host --name s3-active-storage ghcr.io/stackhpc/s3-active-storage-rs:latest
+      - name: Run Reductionist container
+        run: docker run -it --detach --rm --net=host --name reductionist ghcr.io/stackhpc/reductionist-rs:latest
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: activestorage-minio

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -13,7 +13,7 @@ from zarr.indexing import (
     OrthogonalIndexer,
 )
 from activestorage.config import *
-from activestorage.s3 import reduce_chunk as s3_reduce_chunk
+from activestorage.reductionist import reduce_chunk as reductionist_reduce_chunk
 from activestorage.storage import reduce_chunk
 from activestorage import netcdf_to_zarr as nz
 
@@ -390,13 +390,15 @@ class Active:
             parsed_url = urllib.parse.urlparse(rfile)
             bucket = parsed_url.netloc
             object = parsed_url.path
-            tmp, count = s3_reduce_chunk(S3_ACTIVE_STORAGE_URL, S3_ACCESS_KEY,
-                                         S3_SECRET_KEY, S3_URL, bucket,
-                                         object, offset, size,
-                                         compressor, filters, missing,
-                                         self.zds._dtype, self.zds._chunks,
-                                         self.zds._order, chunk_selection,
-                                         operation=self._method)
+            tmp, count = reductionist_reduce_chunk(S3_ACTIVE_STORAGE_URL, S3_ACCESS_KEY,
+                                                   S3_SECRET_KEY, S3_URL,
+                                                   bucket, object, offset,
+                                                   size, compressor, filters,
+                                                   missing, self.zds._dtype,
+                                                   self.zds._chunks,
+                                                   self.zds._order,
+                                                   chunk_selection,
+                                                   operation=self._method)
         else:
             # note there is an ongoing discussion about this interface, and what it returns
             # see https://github.com/valeriupredoi/PyActiveStorage/issues/33

--- a/activestorage/config.py
+++ b/activestorage/config.py
@@ -1,9 +1,9 @@
 # This file contains configuration for PyActiveStorage.
 
-# Whether to use the S3 Active Storage interface.
+# Whether to use the Reductionist Active Storage server interface.
 USE_S3 = False
 
-# URL of S3 Active Storage server.
+# URL of Reductionist server.
 S3_ACTIVE_STORAGE_URL = "http://localhost:8080"
 
 # URL of S3 object store.

--- a/activestorage/reductionist.py
+++ b/activestorage/reductionist.py
@@ -1,4 +1,4 @@
-"""S3 active storage module."""
+"""Reductionist S3 Active Storage server storage interface module."""
 
 import http.client
 import json
@@ -10,9 +10,9 @@ import sys
 def reduce_chunk(server, username, password, source, bucket, object, offset,
                  size, compression, filters, missing, dtype, shape, order,
                  chunk_selection, operation):
-    """Perform a reduction on a chunk using S3 Active Storage.
+    """Perform a reduction on a chunk using Reductionist.
 
-    :param server: S3 active storage server URL
+    :param server: Reductionist server URL
     :param username: S3 username / access key
     :param password: S3 password / secret key
     :param source: S3 URL
@@ -34,7 +34,7 @@ def reduce_chunk(server, username, password, source, bucket, object, offset,
                             obtained or operated upon.
     :param operation: name of operation to perform
     :returns: the reduced data as a numpy array or scalar
-    :raises S3ActiveStorageError: if the request to S3 active storage fails
+    :raises ReductionistError: if the request to Reductionist fails
     """
 
     if compression is not None:
@@ -68,7 +68,7 @@ def encode_selection(selection):
 def build_request_data(source: str, bucket: str, object: str, offset: int,
                        size: int, compression, filters, missing, dtype, shape,
                        order, selection) -> dict:
-    """Build request data for S3 active storage API."""
+    """Build request data for Reductionist API."""
     # TODO: compression, filters, missing
     request_data = {
         'source': source,
@@ -87,7 +87,7 @@ def build_request_data(source: str, bucket: str, object: str, offset: int,
 
 
 def request(url: str, username: str, password: str, request_data: dict):
-    """Make a request to an S3 active storage API."""
+    """Make a request to a Reductionist API."""
     response = requests.post(
         url,
         json=request_data,
@@ -106,17 +106,17 @@ def decode_result(response):
     return result, count
 
 
-class S3ActiveStorageError(Exception):
-    """Exception for S3 Active Storage failures."""
+class ReductionistError(Exception):
+    """Exception for Reductionist failures."""
 
     def __init__(self, status_code, error):
-        super(S3ActiveStorageError, self).__init__(f"S3 Active Storage error: HTTP {status_code}: {error}")
+        super(ReductionistError, self).__init__(f"Reductionist error: HTTP {status_code}: {error}")
 
 
 def decode_and_raise_error(response):
-    """Decode an error response and raise S3ActiveStorageError."""
+    """Decode an error response and raise ReductionistError."""
     try:
         error = json.dumps(response.json())
-        raise S3ActiveStorageError(response.status_code, error)
+        raise ReductionistError(response.status_code, error)
     except requests.exceptions.JSONDecodeError as exc:
-        raise S3ActiveStorageError(response.status_code, "-") from exc
+        raise ReductionistError(response.status_code, "-") from exc

--- a/tests/s3_exploratory/config_minio.py
+++ b/tests/s3_exploratory/config_minio.py
@@ -3,7 +3,7 @@
 # Force True for S3 exploratory tests
 USE_S3 = True
 
-# URL of S3 Active Storage server.
+# URL of Reductionist S3 Active Storage server.
 S3_ACTIVE_STORAGE_URL = "http://localhost:8080"
 
 # URL of S3 object store.

--- a/tests/s3_exploratory/test_s3_reduction.py
+++ b/tests/s3_exploratory/test_s3_reduction.py
@@ -7,7 +7,7 @@ import tempfile
 from activestorage.active import Active
 from activestorage.dummy_data import make_vanilla_ncdata
 import activestorage.storage as st
-from activestorage.s3 import reduce_chunk as s3_reduce_chunk
+from activestorage.reductionist import reduce_chunk as reductionist_reduce_chunk
 from numpy.testing import assert_array_equal
 from pathlib import Path
 
@@ -49,7 +49,7 @@ def upload_to_s3(server, username, password, bucket, object, rfile):
 def test_Active():
     """
     Shows what we expect an active example test to achieve and provides "the right answer"
-    Done twice: POSIX active and S3 active; we compare results.
+    Done twice: POSIX active and Reductionist; we compare results.
 
     identical to tests/test_harness.py::testActive()
 
@@ -129,7 +129,7 @@ def test_with_valid_netCDF_file(test_data_path):
     assert_array_equal(result1, result2)
 
 
-def test_s3_reduce_chunk():
+def test_reductionist_reduce_chunk():
     """Unit test for s3_reduce_chunk."""
     rfile = "tests/test_data/cesm2_native.nc"
     offset = 2
@@ -140,13 +140,11 @@ def test_s3_reduce_chunk():
     upload_to_s3(S3_URL, S3_ACCESS_KEY, S3_SECRET_KEY,
                  S3_BUCKET, object, rfile)
     
-    # call s3_reduce_chunk
-    tmp, count = s3_reduce_chunk(S3_ACTIVE_STORAGE_URL, S3_ACCESS_KEY,
-                                 S3_SECRET_KEY, S3_URL, S3_BUCKET,
-                                 object, offset, size,
-                                 None, None, [],
-                                 np.dtype("int32"), (32, ),
-                                 "C", [slice(0, 2, 1), ],
-                                 "min")
+    # call reductionist_reduce_chunk
+    tmp, count = reductionist_reduce_chunk(S3_ACTIVE_STORAGE_URL, S3_ACCESS_KEY,
+                                           S3_SECRET_KEY, S3_URL, S3_BUCKET,
+                                           object, offset, size, None, None,
+                                           [], np.dtype("int32"), (32, ), "C",
+                                           [slice(0, 2, 1), ], "min")
     assert tmp == 134351386
     assert count == 2

--- a/tests/unit/test_reductionist.py
+++ b/tests/unit/test_reductionist.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 from unittest import mock
 
-from activestorage import s3
+from activestorage import reductionist
 
 
 def make_response(content, status_code, dtype=None, shape=None, count=None):
@@ -20,9 +20,9 @@ def make_response(content, status_code, dtype=None, shape=None, count=None):
     return response
 
 
-@mock.patch.object(s3, 'request')
-def test_s3_reduce_chunk(mock_request):
-    """Unit test for s3_reduce_chunk."""
+@mock.patch.object(reductionist, 'request')
+def test_reduce_chunk(mock_request):
+    """Unit test for reduce_chunk."""
     result = np.int32(134351386)
     response = make_response(result.tobytes(), 200, "int32", "[]", "2")
     mock_request.return_value = response
@@ -46,10 +46,11 @@ def test_s3_reduce_chunk(mock_request):
 
     # no compression, filters, missing
 
-    tmp, count = s3.reduce_chunk(active_url, access_key, secret_key, s3_url,
-                                 bucket, object, offset, size, compression,
-                                 filters, missing, dtype, shape, order,
-                                 chunk_selection, operation)
+    tmp, count = reductionist.reduce_chunk(active_url, access_key, secret_key, s3_url,
+                                           bucket, object, offset, size,
+                                           compression, filters, missing,
+                                           dtype, shape, order,
+                                           chunk_selection, operation)
 
     assert tmp == result
     assert count == 2
@@ -72,9 +73,9 @@ def test_s3_reduce_chunk(mock_request):
                                          expected_data)
 
 
-@mock.patch.object(s3, 'request')
-def test_s3_reduce_chunk_not_found(mock_request):
-    """Unit test for s3_reduce_chunk testing 404 response."""
+@mock.patch.object(reductionist, 'request')
+def test_reduce_chunk_not_found(mock_request):
+    """Unit test for reduce_chunk testing 404 response."""
     result = b'"Not found"'
     response = make_response(result, 404)
     mock_request.return_value = response
@@ -96,10 +97,11 @@ def test_s3_reduce_chunk_not_found(mock_request):
     chunk_selection = [slice(0, 2, 1)]
     operation = "min"
 
-    with pytest.raises(s3.S3ActiveStorageError) as exc:
-        s3.reduce_chunk(active_url, access_key, secret_key, s3_url, bucket,
-                object, offset, size, compression, filters, missing, dtype,
-                shape, order, chunk_selection, operation)
+    with pytest.raises(reductionist.ReductionistError) as exc:
+        reductionist.reduce_chunk(active_url, access_key, secret_key, s3_url, bucket,
+                                  object, offset, size, compression, filters,
+                                  missing, dtype, shape, order,
+                                  chunk_selection, operation)
 
 
-    assert str(exc.value) == 'S3 Active Storage error: HTTP 404: "Not found"'
+    assert str(exc.value) == 'Reductionist error: HTTP 404: "Not found"'

--- a/tests/unit/test_storage_types.py
+++ b/tests/unit/test_storage_types.py
@@ -17,7 +17,7 @@ from activestorage.active import Active
 from activestorage.config import *
 from activestorage.dummy_data import make_vanilla_ncdata
 from activestorage import netcdf_to_zarr
-import activestorage.s3
+import activestorage.reductionist
 import activestorage.storage
 
 
@@ -27,7 +27,7 @@ old_netcdf_to_zarr = netcdf_to_zarr.load_netcdf_zarr_generic
 
 @mock.patch.object(activestorage.active, "load_from_s3")
 @mock.patch.object(activestorage.netcdf_to_zarr, "load_netcdf_zarr_generic")
-@mock.patch.object(activestorage.active, "s3_reduce_chunk")
+@mock.patch.object(activestorage.active, "reductionist_reduce_chunk")
 def test_s3(mock_reduce, mock_nz, mock_load, tmp_path):
     """Test stack when call to Active contains storage_type == s3."""
 
@@ -127,8 +127,8 @@ def test_s3_load_failure(mock_load):
 
 @mock.patch.object(activestorage.active, "load_from_s3")
 @mock.patch.object(activestorage.netcdf_to_zarr, "load_netcdf_zarr_generic")
-@mock.patch.object(activestorage.active, "s3_reduce_chunk")
-def test_s3_active_storage_connection(mock_reduce, mock_nz, mock_load, tmp_path):
+@mock.patch.object(activestorage.active, "reductionist_reduce_chunk")
+def test_reductionist_connection(mock_reduce, mock_nz, mock_load, tmp_path):
     """Test stack when call to Active contains storage_type == s3."""
 
     @contextlib.contextmanager
@@ -156,8 +156,8 @@ def test_s3_active_storage_connection(mock_reduce, mock_nz, mock_load, tmp_path)
 
 @mock.patch.object(activestorage.active, "load_from_s3")
 @mock.patch.object(activestorage.netcdf_to_zarr, "load_netcdf_zarr_generic")
-@mock.patch.object(activestorage.active, "s3_reduce_chunk")
-def test_s3_active_storage_bad_request(mock_reduce, mock_nz, mock_load, tmp_path):
+@mock.patch.object(activestorage.active, "reductionist_reduce_chunk")
+def test_reductionist_bad_request(mock_reduce, mock_nz, mock_load, tmp_path):
     """Test stack when call to Active contains storage_type == s3."""
 
     @contextlib.contextmanager
@@ -169,7 +169,7 @@ def test_s3_active_storage_bad_request(mock_reduce, mock_nz, mock_load, tmp_path
 
     mock_load.side_effect = load_from_s3
     mock_nz.side_effect = load_netcdf_zarr_generic
-    mock_reduce.side_effect = activestorage.s3.S3ActiveStorageError(400, "Bad request")
+    mock_reduce.side_effect = activestorage.reductionist.ReductionistError(400, "Bad request")
 
     uri = "s3://fake-bucket/fake-object"
     test_file = str(tmp_path / "test.nc")
@@ -179,5 +179,5 @@ def test_s3_active_storage_bad_request(mock_reduce, mock_nz, mock_load, tmp_path
     active._version = 1
     active._method = "max"
 
-    with pytest.raises(activestorage.s3.S3ActiveStorageError):
+    with pytest.raises(activestorage.reductionist.ReductionistError):
         assert active[::]


### PR DESCRIPTION
The S3 Active Storage project has been rebranded to Reductionist!

This change updates references to it in PyActiveStorage.

https://github.com/stackhpc/reductionist-rs
