### PR TITLE
Add support for missing data in S3 storage backend

### DIFF
--- a/tests/s3_exploratory/test_s3_reduction.py
+++ b/tests/s3_exploratory/test_s3_reduction.py
@@ -8,7 +8,7 @@ from activestorage.active import Active
 from activestorage.dummy_data import make_vanilla_ncdata
 import activestorage.storage as st
 from activestorage.reductionist import reduce_chunk as reductionist_reduce_chunk
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 from pathlib import Path
 
 from config_minio import *
@@ -123,10 +123,11 @@ def test_with_valid_netCDF_file(test_data_path):
 
     # expect {'sum': array([[[2368.3232]]], dtype=float32), 'n': array([[[8]]])}
     # check for typing and structure
-    np.testing.assert_array_equal(result1["sum"], np.array([[[2368.3232]]], dtype="float32"))
-    np.testing.assert_array_equal(result1["n"], np.array([[[8]]]))
+    assert_allclose(result1["sum"], np.array([[[2368.3232]]], dtype="float32"), rtol=1e-6)
+    assert_array_equal(result1["n"], np.array([[[8]]]))
 
-    assert_array_equal(result1, result2)
+    assert_allclose(result1["sum"], result2["sum"], rtol=1e-6)
+    assert_array_equal(result1["n"], result2["n"])
 
 
 def test_reductionist_reduce_chunk():

--- a/tests/test_bigger_data.py
+++ b/tests/test_bigger_data.py
@@ -206,10 +206,10 @@ def test_cesm2_native(test_data_path):
     print(result2, ncfile)
     # expect {'sum': array([[[2368.3232]]], dtype=float32), 'n': array([[[8]]])}
     # check for typing and structure
-    np.testing.assert_array_equal(result2["sum"], np.array([[[2368.3232]]], dtype="float32"))
+    np.testing.assert_allclose(result2["sum"], np.array([[[2368.3232]]], dtype="float32"), rtol=1e-6)
     np.testing.assert_array_equal(result2["n"], np.array([[[8]]]))
     # check for active
-    np.testing.assert_array_equal(mean_result, result2["sum"]/result2["n"])
+    np.testing.assert_allclose(mean_result, result2["sum"]/result2["n"], rtol=1e-6)
 
 
 def test_daily_data(test_data_path):

--- a/tests/test_missing.py
+++ b/tests/test_missing.py
@@ -36,7 +36,7 @@ def active_zero(testfile):
     # FIXME: For the S3 backend, h5netcdf is used to read the metadata. It does
     # not seem to load the missing data attributes (missing_value, _FillValue,
     # valid_min, valid_max, valid_range, etc).
-    assert ma.is_masked(d) == (not USE_S3)
+    assert ma.is_masked(d)
 
     return np.mean(d)
 
@@ -75,10 +75,7 @@ def test_partially_missing_data(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
     np.testing.assert_array_equal(no_active_mean, active_mean)
 
 
@@ -103,10 +100,7 @@ def test_missing(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
     np.testing.assert_array_equal(no_active_mean, active_mean)
 
 
@@ -136,10 +130,7 @@ def test_fillvalue(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
     np.testing.assert_array_equal(no_active_mean, active_mean)
 
 
@@ -174,10 +165,7 @@ def test_validmin(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
     np.testing.assert_array_equal(no_active_mean, active_mean)
 
 
@@ -215,10 +203,8 @@ def test_validmax(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(no_active_mean, active_mean)
 
 
 def test_validrange(tmp_path):
@@ -252,7 +238,5 @@ def test_validrange(tmp_path):
     active_mean = active_two(testfile)
     print("Active storage result (mean)", active_mean)
 
-    if not USE_S3:
-        np.testing.assert_array_equal(masked_numpy_mean, active_mean)
-    else:
-        np.testing.assert_array_equal(unmasked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(masked_numpy_mean, active_mean)
+    np.testing.assert_array_equal(no_active_mean, active_mean)

--- a/tests/unit/test_reductionist.py
+++ b/tests/unit/test_reductionist.py
@@ -83,16 +83,16 @@ def test_reduce_chunk_defaults(mock_request):
             {"missing_values": [np.float64(42.), np.float64(-42.)]},
         ),
         (
-            (None, None, np.float32(1e20), None),
-            {"valid_min": np.float64(np.float32(1e20))},
+            (None, None, np.float32(-1e6), None),
+            {"valid_min": np.float64(np.float32(-1e6))},
         ),
         (
-            (None, None, None, np.float32(1e-20)),
-            {"valid_max": np.float64(np.float32(1e-20))},
+            (None, None, None, np.float32(1e6)),
+            {"valid_max": np.float64(np.float32(1e6))},
         ),
         (
-            (None, None, np.float32(1e-20), np.float32(1e20)),
-            {"valid_range": [np.float64(np.float32(1e-20)), np.float64(np.float32(1e20))]},
+            (None, None, np.float32(-1e6), np.float32(1e6)),
+            {"valid_range": [np.float64(np.float32(-1e6)), np.float64(np.float32(1e6))]},
         ),
     ]
 )

--- a/tests/unit/test_reductionist.py
+++ b/tests/unit/test_reductionist.py
@@ -21,10 +21,88 @@ def make_response(content, status_code, dtype=None, shape=None, count=None):
 
 
 @mock.patch.object(reductionist, 'request')
-def test_reduce_chunk(mock_request):
-    """Unit test for reduce_chunk."""
+def test_reduce_chunk_defaults(mock_request):
+    """Unit test for reduce_chunk with default arguments."""
     result = np.int32(134351386)
     response = make_response(result.tobytes(), 200, "int32", "[]", "2")
+    mock_request.return_value = response
+
+    active_url = "https://s3.example.com"
+    access_key = "fake-access"
+    secret_key = "fake-secret"
+    s3_url = "https://active.example.com"
+    bucket = "fake-bucket"
+    object = "fake-object"
+    offset = None
+    size = None
+    compression = None
+    filters = None
+    missing = (None, None, None, None)
+    dtype = np.dtype("int32")
+    shape = None
+    order = None
+    chunk_selection = None
+    operation = "min"
+
+    # no support for compression, filters
+
+    tmp, count = reductionist.reduce_chunk(active_url, access_key, secret_key,
+                                           s3_url, bucket, object, offset,
+                                           size, compression, filters, missing,
+                                           dtype, shape, order,
+                                           chunk_selection, operation)
+
+    assert tmp == result
+    assert count == 2
+
+    expected_url = f"{active_url}/v1/{operation}/"
+    expected_data = {
+        "source": s3_url,
+        "bucket": bucket,
+        "object": object,
+        "dtype": "int32",
+    }
+    mock_request.assert_called_once_with(expected_url, access_key, secret_key,
+                                         expected_data)
+
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        (
+            (np.float32(42.), None, None, None),
+            {"missing_value": np.float64(42.)},
+        ),
+        (
+            (None, np.float32(-42.), None, None),
+            {"missing_value": np.float64(-42.)},
+        ),
+        (
+            (None, [np.float32(42.), np.float32(-42.)], None, None),
+            {"missing_values": [np.float64(42.), np.float64(-42.)]},
+        ),
+        (
+            (None, None, np.float32(1e20), None),
+            {"valid_min": np.float64(np.float32(1e20))},
+        ),
+        (
+            (None, None, None, np.float32(1e-20)),
+            {"valid_max": np.float64(np.float32(1e-20))},
+        ),
+        (
+            (None, None, np.float32(1e-20), np.float32(1e20)),
+            {"valid_range": [np.float64(np.float32(1e-20)), np.float64(np.float32(1e20))]},
+        ),
+    ]
+)
+@mock.patch.object(reductionist, 'request')
+def test_reduce_chunk_missing(mock_request, missing):
+    """Unit test for reduce_chunk."""
+    reduce_arg, api_arg = missing
+
+    result = np.float32(-42.)
+    response = make_response(result.tobytes(), 200, "float32", "[]", "2")
     mock_request.return_value = response
 
     active_url = "https://s3.example.com"
@@ -37,14 +115,14 @@ def test_reduce_chunk(mock_request):
     size = 128
     compression = None
     filters = None
-    missing = []
-    dtype = np.dtype("int32")
+    missing = reduce_arg
+    dtype = np.dtype("float32")
     shape = (32, )
     order = "C"
     chunk_selection = [slice(0, 2, 1)]
     operation = "min"
 
-    # no compression, filters, missing
+    # no compression, filters
 
     tmp, count = reductionist.reduce_chunk(active_url, access_key, secret_key, s3_url,
                                            bucket, object, offset, size,
@@ -60,7 +138,7 @@ def test_reduce_chunk(mock_request):
         "source": s3_url,
         "bucket": bucket,
         "object": object,
-        "dtype": "int32",
+        "dtype": "float32",
         "offset": offset,
         "size": size,
         "order": order,
@@ -68,6 +146,7 @@ def test_reduce_chunk(mock_request):
         "selection": [[chunk_selection[0].start,
                        chunk_selection[0].stop,
                        chunk_selection[0].step]],
+        "missing": api_arg,
     }
     mock_request.assert_called_once_with(expected_url, access_key, secret_key,
                                          expected_data)


### PR DESCRIPTION
Uses the new missing data support in Reductionist, added in [1] (with
API tests in [2]).

It supports specifying at most the following missing data types:

* a single missing value
* multiple missing values
* a valid minimum
* a valid maximum
* a valid range

There are some limitations:

1. JSON numbers (used to represent the missing data values) cannot
   represent infinities or NaN.
2. It's unclear whether there will be rounding issues when converting
   floating point JSON numbers to float32 or float64. I haven't seen any
   issues yet, but that doesn't mean they don't exist.
3. Only one of the missing data types may be specified.

If necessary, 1 and 2 could be avoided by encoding numbers using e.g.
base64. 3 could be avoided by allowing a combination of missing values
and upper/lower bounds.

Currently this client interface does not support passing multiple
missing values. This should be added along with a test case and support
for the same in the local storage backend.

[1] https://github.com/stackhpc/reductionist-rs/pull/62
[2] https://github.com/stackhpc/s3-active-storage-compliance-suite/pull/17

Closes #124
Closes #127
