### PR TITLE
Add support for byte order (endianness)

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -107,6 +107,9 @@ class Active:
                 print(f"Dataset {ds} does not contain ncvar {ncvar!r}.")
                 raise exc
 
+            # FIXME: We do not get the correct byte order on the Zarr Array's dtype
+            # when using S3, so capture it here.
+            self._dtype = ds_var.dtype
             try:
                 self._filters = ds_var.filters()
             # ds from h5netcdf may not have _filters and other such metadata
@@ -410,11 +413,14 @@ class Active:
             parsed_url = urllib.parse.urlparse(rfile)
             bucket = parsed_url.netloc
             object = parsed_url.path
+            # FIXME: We do not get the correct byte order on the Zarr Array's dtype
+            # when using S3, so use the value captured earlier.
+            dtype = self._dtype
             tmp, count = reductionist_reduce_chunk(S3_ACTIVE_STORAGE_URL, S3_ACCESS_KEY,
                                                    S3_SECRET_KEY, S3_URL,
                                                    bucket, object, offset,
                                                    size, compressor, filters,
-                                                   missing, self.zds._dtype,
+                                                   missing, dtype,
                                                    self.zds._chunks,
                                                    self.zds._order,
                                                    chunk_selection,

--- a/activestorage/reductionist.py
+++ b/activestorage/reductionist.py
@@ -24,7 +24,7 @@ def reduce_chunk(server, username, password, source, bucket, object, offset,
     :param compression: name of compression, unsupported
     :param filters: name of filters, unsupported
     :param missing: optional 4-tuple describing missing data
-    :param dtype: data type name
+    :param dtype: numpy data type
     :param shape: will be a tuple, something like (3,3,1), this is the
                   dimensionality of the chunk itself
     :param order: typically 'C' for c-type ordering
@@ -52,6 +52,17 @@ def reduce_chunk(server, username, password, source, bucket, object, offset,
         return decode_result(response)
     else:
         decode_and_raise_error(response)
+
+
+def encode_byte_order(dtype):
+    """Encode the byte order (endianness) of a dtype in a JSON-compatible format."""
+    if dtype.byteorder == '=':
+        return sys.byteorder
+    elif dtype.byteorder == '<':
+        return 'little'
+    elif dtype.byteorder == '>':
+        return 'big'
+    assert False, "Unexpected byte order {dtype.byteorder}"
 
 
 def encode_selection(selection):
@@ -103,6 +114,7 @@ def build_request_data(source: str, bucket: str, object: str, offset: int,
         'bucket': bucket,
         'object': object,
         'dtype': dtype.name,
+        'byte_order': encode_byte_order(dtype),
         'offset': offset,
         'size': size,
         'order': order,

--- a/tests/test_byte_order.py
+++ b/tests/test_byte_order.py
@@ -1,0 +1,45 @@
+import os
+import pytest
+
+from netCDF4 import Dataset
+
+from activestorage.active import Active
+from activestorage.config import *
+from activestorage.dummy_data import make_byte_order_ncdata
+
+import utils
+
+
+def check_dataset_byte_order(temp_file: str, ncvar: str, byte_order: str):
+    # Sanity check that test data has expected byte order (endianness).
+    with Dataset(temp_file) as test_data:
+        assert test_data.variables[ncvar].endian() == byte_order
+
+
+def create_byte_order_dataset(tmp_path: str, byte_order: str):
+    """
+    Make a vanilla test dataset which has the specified byte order (endianness).
+    """
+    temp_file = str(tmp_path / "test_byte_order.nc")
+    test_data = make_byte_order_ncdata(filename=temp_file, byte_order=byte_order)
+
+    check_dataset_byte_order(temp_file, "data", byte_order)
+
+    test_file = utils.write_to_storage(temp_file)
+    if USE_S3:
+        os.remove(temp_file)
+    return test_file
+
+
+@pytest.mark.parametrize('byte_order', ['big', 'little'])
+def test_byte_order(tmp_path: str, byte_order: str):
+    """
+    Test use of datasets with different byte orders (endianness).
+    """
+    test_file = create_byte_order_dataset(tmp_path, byte_order)
+
+    active = Active(test_file, 'data', utils.get_storage_type())
+    active._version = 1
+    active._method = "min"
+    result = active[0:2,4:6,7:9]
+    assert result == 740.0

--- a/tests/unit/test_reductionist.py
+++ b/tests/unit/test_reductionist.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pytest
 import requests
+import sys
 from unittest import mock
 
 from activestorage import reductionist
@@ -61,6 +62,7 @@ def test_reduce_chunk_defaults(mock_request):
         "bucket": bucket,
         "object": object,
         "dtype": "int32",
+        "byte_order": sys.byteorder,
     }
     mock_request.assert_called_once_with(expected_url, access_key, secret_key,
                                          expected_data)
@@ -116,7 +118,7 @@ def test_reduce_chunk_missing(mock_request, missing):
     compression = None
     filters = None
     missing = reduce_arg
-    dtype = np.dtype("float32")
+    dtype = np.dtype("float32").newbyteorder()
     shape = (32, )
     order = "C"
     chunk_selection = [slice(0, 2, 1)]
@@ -139,6 +141,7 @@ def test_reduce_chunk_missing(mock_request, missing):
         "bucket": bucket,
         "object": object,
         "dtype": "float32",
+        "byte_order": "little" if sys.byteorder == "big" else "big",
         "offset": offset,
         "size": size,
         "order": order,


### PR DESCRIPTION
netCDF4 variables are written with a specific byte order (endianness),
typically the same as the machine writing to the dataset. In
netCDF4-python this shows up in the variable's dtype.byteorder, and may
be '<' (little), '>' (big) or '=' (native).

For the local storage backend this generally "just works", since the
numpy array returned by netCDF4-python has the correct byte ordering.

For files in an S3 store, kerchunk uses h5py to read the netCDF4 dataset
when converting it to a Zarr array index. In this case the byte order of
the dtype on the Zarr array is not always correct, and sometimes shows
up as big endian even though little endian was specified. We work around
this by capturing the dtype of the dataset when reading other attributes
(filters, metadata, etc.).

Closes #76
