### PR TITLE
Always load netCDF metadata

### DIFF
--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -95,21 +95,22 @@ class Active:
         # FIXME: There is an outstanding issue with ._FilLValue to be handled.
         # If the user actually wrote the data with no fill value, or the
         # default fill value is in play, then this might go wrong.
-        if (missing_value, _FillValue, valid_min, valid_max) == (None, None, None, None):
-            if storage_type is None:
-                ds = Dataset(uri)
-            elif storage_type == "s3":
-                with load_from_s3(uri) as _ds:
-                    ds = _ds
-            try:
-                ds_var = ds[ncvar]
-            except IndexError as exc:
-                print(f"Dataset {ds} does not contain ncvar {ncvar!r}.")
-                raise exc
+        if storage_type is None:
+            ds = Dataset(uri)
+        elif storage_type == "s3":
+            with load_from_s3(uri) as _ds:
+                ds = _ds
+        try:
+            ds_var = ds[ncvar]
+        except IndexError as exc:
+            print(f"Dataset {ds} does not contain ncvar {ncvar!r}.")
+            raise exc
 
-            # FIXME: We do not get the correct byte order on the Zarr Array's dtype
-            # when using S3, so capture it here.
-            self._dtype = ds_var.dtype
+        # FIXME: We do not get the correct byte order on the Zarr Array's dtype
+        # when using S3, so capture it here.
+        self._dtype = ds_var.dtype
+
+        if (missing_value, _FillValue, valid_min, valid_max) == (None, None, None, None):
             if isinstance(ds, Dataset):
                 self._missing = getattr(ds_var, 'missing_value', None)
                 self._fillvalue = getattr(ds_var, '_FillValue', None)
@@ -141,12 +142,13 @@ class Active:
                 valid_range = (None, None)
             self._valid_min, self._valid_max = valid_range
 
-            ds.close()
         else:
             self._missing = missing_value
             self._fillvalue = _FillValue
             self._valid_min = valid_min
             self._valid_max = valid_max
+
+        ds.close()
 
     def __getitem__(self, index):
         """ 

--- a/tests/test_bigger_data.py
+++ b/tests/test_bigger_data.py
@@ -237,7 +237,6 @@ def test_daily_data(test_data_path):
     np.testing.assert_array_equal(mean_result, result2["sum"]/result2["n"])
 
 
-@pytest.mark.xfail(USE_S3, reason="Missing data not supported in S3 yet")
 def test_daily_data_masked(test_data_path):
     """
     Test again with a daily data file, with masking on
@@ -258,7 +257,7 @@ def test_daily_data_masked(test_data_path):
     print(result2, ncfile)
     # expect {'sum': array([[[[169632.5]]]], dtype=float32), 'n': 680}
     # check for typing and structure
-    np.testing.assert_array_equal(result2["sum"], np.array([[[[169632.5]]]], dtype="float32"))
+    np.testing.assert_allclose(result2["sum"], np.array([[[[169632.5]]]], dtype="float32"), rtol=1e-6)
     np.testing.assert_array_equal(result2["n"], 680)
     # check for active
-    np.testing.assert_array_equal(mean_result, result2["sum"]/result2["n"])
+    np.testing.assert_allclose(mean_result, result2["sum"]/result2["n"], rtol=1e-6)


### PR DESCRIPTION
Since byte order support was added in #132, we capture the dtype from
netCDF metadata and use it in preference to the Zarr dtype when using
the S3 storage backend.

In the case where missing data values are passed into the Active
constructor, we do not load netCDF metadata, and therefore do not
capture the dtype. This leads to the following error with S3 storage:

  AttributeError: 'Active' object has no attribute '_dtype'

This change switches to always load the metadata so that we can capture
the dtype.  This has the downside that it is not necessary when using
local storage and missing data has been specified.

This allows us to enable the test_daily_data_masked test for S3.

Closes #137
