### PR TITLE
[conda-lock] do not install pip post-facto and use it straight from the lock environment

### DIFF
--- a/.github/workflows/install-from-condalock-file.yml
+++ b/.github/workflows/install-from-condalock-file.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - use_lock_pip
   # run the test only if the PR is to main
   # turn it on if required
   # pull_request:

--- a/.github/workflows/install-from-condalock-file.yml
+++ b/.github/workflows/install-from-condalock-file.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - use_lock_pip
   # run the test only if the PR is to main
   # turn it on if required
   # pull_request:
@@ -37,7 +38,6 @@ jobs:
       - run: which python
       - run: python -V
       - run: conda create --name activestorage-fromlock --file conda-linux-64.lock
-      - run: conda install pip
       - run: which python
       - run: pip --version
       - run: pip install -e .


### PR DESCRIPTION
…onment

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

[conda lock install tests](https://github.com/valeriupredoi/PyActiveStorage/actions/runs/7040567930/job/19161711402) failing prompted me to a vulnerability that should have been corrected long ago :+1: Instead of installing `pip` post-facto (after environment has been created) with the risk of overwriting the correctly installed version via conda lock, we just keep what came with the lock file.


## Before you get started

- ~[ ] [☝ Create an issue](https://github.com/valeriupredoi/PyActiveStorage/issues) to discuss what you are going to do~

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] All tests pass
