### PR TITLE
Pin `numcodecs>=0.12` to avoid compression kerfuffle for Python<3.12

### DIFF
--- a/.github/workflows/test_s3_minio.yml
+++ b/.github/workflows/test_s3_minio.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main  # keep this at all times
+      - pin_numcodecs
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # nightly

--- a/.github/workflows/test_s3_minio.yml
+++ b/.github/workflows/test_s3_minio.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main  # keep this at all times
-      - pin_numcodecs
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # nightly

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - h5py  # needed by Kerchunk
   - kerchunk
   - netcdf4
+  - numcodecs >=0.12  # github.com/valeriupredoi/PyActiveStorage/issues/162
   - numpy !=1.24.3  # severe masking bug
   - pip !=21.3
   - s3fs

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ REQUIREMENTS = {
         'h5py',  # needed by Kerchunk
         'kerchunk',
         'netcdf4',
+        'numcodecs>=0.12',  # github/issues/162
         'numpy!=1.24.3',  # severe masking bug
         's3fs',
         # pin Zarr to use new FSStore instead of KVStore


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #162


## Before you get started

- [x] [☝ Create an issue](https://github.com/valeriupredoi/PyActiveStorage/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- ~[ ] Unit tests have been added (if codecov test fails)~
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] All tests pass
