### PR TITLE
Correct handling of key and secret for S3 `session` and actual test with key-secret bucket

### DIFF
--- a/.github/workflows/test_s3_remote_reductionist.yml
+++ b/.github/workflows/test_s3_remote_reductionist.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Export proxy
         run: |
           echo 'USE_S3 = True' >> activestorage/config.py
+          echo 'REMOTE_RED = True' >> activestorage/config.py
       - name: Ping remote Reductionist
         run: curl -k https://192.171.169.248:8080/.well-known/reductionist-schema
       - uses: conda-incubator/setup-miniconda@v2

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -348,8 +348,21 @@ class Active:
 
         # Create a shared session object.
         if self.storage_type == "s3":
-            session = reductionist.get_session(S3_ACCESS_KEY, S3_SECRET_KEY,
-                                               S3_ACTIVE_STORAGE_CACERT)
+            if self.storage_options is not None:
+                key, secret = None, None
+                if "key" in self.storage_options:
+                    key = self.storage_options["key"]
+                if "secret" in self.storage_options:
+                    secret = self.storage_options["secret"]
+                if key and secret:
+                    session = reductionist.get_session(key, secret,
+                                                       S3_ACTIVE_STORAGE_CACERT)
+                else:
+                    session = reductionist.get_session(S3_ACCESS_KEY, S3_SECRET_KEY,
+                                                       S3_ACTIVE_STORAGE_CACERT)
+            else:
+                session = reductionist.get_session(S3_ACCESS_KEY, S3_SECRET_KEY,
+                                                   S3_ACTIVE_STORAGE_CACERT)
         else:
             session = None
 

--- a/activestorage/active.py
+++ b/activestorage/active.py
@@ -451,12 +451,20 @@ class Active:
 
         # S3: pass in pre-configured storage options (credentials)
         if self.storage_type == "s3":
+            print("S3 rfile is:", rfile)
             parsed_url = urllib.parse.urlparse(rfile)
             bucket = parsed_url.netloc
             object = parsed_url.path
             # FIXME: We do not get the correct byte order on the Zarr Array's dtype
             # when using S3, so use the value captured earlier.
             dtype = self._dtype
+            # for certain S3 servers rfile needs to contain the bucket eg "bucket/filename"
+            # as a result the parser above finds empty string bucket
+            if bucket == "":
+                bucket = os.path.dirname(object)
+                object = os.path.basename(object)
+            print("S3 bucket:", bucket)
+            print("S3 file:", object)
             if self.storage_options is None:
                 tmp, count = reductionist.reduce_chunk(session,
                                                        S3_ACTIVE_STORAGE_URL,

--- a/activestorage/config.py
+++ b/activestorage/config.py
@@ -20,3 +20,6 @@ S3_SECRET_KEY = "minioadmin"
 
 # S3 bucket.
 S3_BUCKET = "pyactivestorage"
+
+# Remote Reductionist or not
+REMOTE_RED = False

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -145,6 +145,7 @@ def test_compression_and_filters_cmip6_forced_s3_from_local_2():
 
 
 @pytest.mark.skipif(not USE_S3, reason="we need only localhost Reductionist in GA CI")
+@pytest.mark.skipif(REMOTE_RED, reason="we need only localhost Reductionist in GA CI")
 def test_compression_and_filters_cmip6_forced_s3_using_local_Reductionist():
     """
     Test use of datasets with compression and filters applied for a real

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -26,7 +26,6 @@ storage_options_paramlist = [
 # bucket needed too for this test only
 # otherwise, bucket is extracted automatically from full file uri
 S3_BUCKET = "bnl"
-ACTIVE_URLS = [S3_ACTIVE_URL_Bryan]  # S3_ACTIVE_STORAGE_URL]
 
 @pytest.mark.parametrize("storage_options, active_storage_url", storage_options_paramlist)
 def test_compression_and_filters_cmip6_data(storage_options, active_storage_url):

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -26,7 +26,7 @@ storage_options_paramlist = [
 # bucket needed too for this test only
 # otherwise, bucket is extracted automatically from full file uri
 S3_BUCKET = "bnl"
-ACTIVE_URLS = [S3_ACTIVE_URL_Bryan, S3_ACTIVE_STORAGE_URL]
+ACTIVE_URLS = [S3_ACTIVE_URL_Bryan]  # S3_ACTIVE_STORAGE_URL]
 
 @pytest.mark.parametrize("storage_options, active_storage_url", storage_options_paramlist)
 def test_compression_and_filters_cmip6_data(storage_options, active_storage_url):
@@ -109,8 +109,7 @@ def test_compression_and_filters_cmip6_forced_s3_from_local(storage_options, act
     # assert result == 239.25946044921875
 
 
-@pytest.mark.parametrize("active_storage_url", ACTIVE_URLS)
-def test_compression_and_filters_cmip6_forced_s3_from_local_2(active_storage_url):
+def test_compression_and_filters_cmip6_forced_s3_from_local_2():
     """
     Test use of datasets with compression and filters applied for a real
     CMIP6 dataset (CMIP6-test.nc) - an IPSL file.
@@ -122,6 +121,7 @@ def test_compression_and_filters_cmip6_forced_s3_from_local_2(active_storage_url
         'secret': "$/'#M{0{/4rVhp%n^(XeX$q@y#&(NM3W1->~N.Q6VP.5[@bLpi='nt]AfH)>78pT",
         'client_kwargs': {'endpoint_url': "https://uor-aces-o.s3-ext.jc.rl.ac.uk"}
     }
+    active_storage_url = "https://192.171.169.248:8080"
     test_file = str(Path(__file__).resolve().parent / 'test_data' / 'CMIP6-test.nc')
     with Dataset(test_file) as nc_data:
         nc_min = np.min(nc_data["tas"][0:2,4:6,7:9])

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -26,7 +26,7 @@ storage_options_paramlist = [
 # bucket needed too for this test only
 # otherwise, bucket is extracted automatically from full file uri
 S3_BUCKET = "bnl"
-
+ACTIVE_URLS = [S3_ACTIVE_URL_Bryan, S3_ACTIVE_STORAGE_URL]
 
 @pytest.mark.parametrize("storage_options, active_storage_url", storage_options_paramlist)
 def test_compression_and_filters_cmip6_data(storage_options, active_storage_url):
@@ -107,3 +107,39 @@ def test_compression_and_filters_cmip6_forced_s3_from_local(storage_options, act
     assert access_denied_err in str(rederr.value)
     # assert nc_min == result
     # assert result == 239.25946044921875
+
+
+@pytest.mark.parametrize("active_storage_url", ACTIVE_URLS)
+def test_compression_and_filters_cmip6_forced_s3_from_local_2(active_storage_url):
+    """
+    Test use of datasets with compression and filters applied for a real
+    CMIP6 dataset (CMIP6-test.nc) - an IPSL file.
+
+    This is for a special anon=True bucket connected to via valid key.secret
+    """
+    storage_options = {
+        'key': "f2d55c6dcfc7618b2c34e00b58df3cef",
+        'secret': "$/'#M{0{/4rVhp%n^(XeX$q@y#&(NM3W1->~N.Q6VP.5[@bLpi='nt]AfH)>78pT",
+        'client_kwargs': {'endpoint_url': "https://uor-aces-o.s3-ext.jc.rl.ac.uk"}
+    }
+    test_file = str(Path(__file__).resolve().parent / 'test_data' / 'CMIP6-test.nc')
+    with Dataset(test_file) as nc_data:
+        nc_min = np.min(nc_data["tas"][0:2,4:6,7:9])
+    print(f"Numpy min from compressed file {nc_min}")
+
+    ofile = os.path.basename(test_file)
+    test_file_uri = os.path.join(
+        S3_BUCKET,
+        ofile
+    )
+    print("S3 Test file path:", test_file_uri)
+    active = Active(test_file_uri, 'tas', storage_type="s3",
+                    storage_options=storage_options,
+                    active_storage_url=active_storage_url)
+
+    active._version = 1
+    active._method = "min"
+
+    result = active[0:2,4:6,7:9]
+    assert nc_min == result
+    assert result == 239.25946044921875


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

OK it actually works: a netCDF4 file in an actual S3 bucket (with key and secret, NOT anon=True), a Reductionist deployed elsewhere, and a PyActiveStorage client some other place too :beers: Look at the [GA Action](https://github.com/valeriupredoi/PyActiveStorage/actions/runs/7919134087/job/21619193277?pr=183) and the test of interest is the beautifully named: `tests/test_compression_remote_reductionist.py::test_compression_and_filters_cmip6_forced_s3_from_local_2` - boom!

The reason why this is labeled as "bug" is that it took me a good part of today figuring out that the Reductionist `session` was getting built with the config.py's `S3_ACCESS_KEY` and `S3_SECRET_KEY` regardless of what S3 bucket the test was pointing to :man_facepalming: 

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] All tests pass
