### PR TITLE
Replace `default_cache_type` with `first`

### DIFF
--- a/activestorage/netcdf_to_zarr.py
+++ b/activestorage/netcdf_to_zarr.py
@@ -17,8 +17,8 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
         fs = s3fs.S3FileSystem(key=S3_ACCESS_KEY,
                                secret=S3_SECRET_KEY,
                                client_kwargs={'endpoint_url': S3_URL},
-                               # default_fill_cache=False,
-                               # default_cache_type="none"
+                               default_fill_cache=False,
+                               default_cache_type="first"  # best for HDF5
         )
         fs2 = fsspec.filesystem('')
         with fs.open(file_url, 'rb') as s3file:
@@ -31,8 +31,8 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
     # S3 passed-in configuration
     elif storage_type == "s3" and storage_options is not None:
         storage_options = storage_options.copy()
-        # storage_options['default_fill_cache'] = False
-        # storage_options['default_cache_type'] = "none"
+        storage_options['default_fill_cache'] = False
+        storage_options['default_cache_type'] = "first"  # best for HDF5
         fs = s3fs.S3FileSystem(**storage_options)
         fs2 = fsspec.filesystem('')
         with fs.open(file_url, 'rb') as s3file:

--- a/activestorage/netcdf_to_zarr.py
+++ b/activestorage/netcdf_to_zarr.py
@@ -17,8 +17,8 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
         fs = s3fs.S3FileSystem(key=S3_ACCESS_KEY,
                                secret=S3_SECRET_KEY,
                                client_kwargs={'endpoint_url': S3_URL},
-                               default_fill_cache=False,
-                               default_cache_type="none"
+                               # default_fill_cache=False,
+                               # default_cache_type="none"
         )
         fs2 = fsspec.filesystem('')
         with fs.open(file_url, 'rb') as s3file:
@@ -31,8 +31,8 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
     # S3 passed-in configuration
     elif storage_type == "s3" and storage_options is not None:
         storage_options = storage_options.copy()
-        storage_options['default_fill_cache'] = False
-        storage_options['default_cache_type'] = "none"
+        # storage_options['default_fill_cache'] = False
+        # storage_options['default_cache_type'] = "none"
         fs = s3fs.S3FileSystem(**storage_options)
         fs2 = fsspec.filesystem('')
         with fs.open(file_url, 'rb') as s3file:


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Replacing `default_cache_type` to `first` (the recommended type when dealing with HDF5 files - many thanks @martindurant :beer: ) has a significant impact on timing performance.

## Checklist

- [x] This pull request has a descriptive title and labels
- [ ] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- ~[ ] Unit tests have been added (if codecov test fails)~
- ~[ ] Any changed dependencies have been added or removed correctly (if need be)~
- [x] All tests pass
