### PR TITLE
Pin `kerchunk >=0.2.4` and fix change of API in new Kerchunk: compressor is now a filter

### DIFF
--- a/activestorage/netcdf_to_zarr.py
+++ b/activestorage/netcdf_to_zarr.py
@@ -127,6 +127,9 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
             # for active storage, we don't want anything inline
             with fs.open(outf, 'wb') as f:
                 content = h5chunks.translate()
+                content = _correct_compressor_and_filename(content,
+                                                           varname,
+                                                           bryan_bucket=False)
                 f.write(ujson.dumps(content).encode())
 
     zarray =  ujson.loads(content['refs'][f"{varname}/.zarray"])

--- a/activestorage/netcdf_to_zarr.py
+++ b/activestorage/netcdf_to_zarr.py
@@ -10,6 +10,48 @@ from activestorage.config import *
 from kerchunk.hdf import SingleHdf5ToZarr
 
 
+def _correct_compressor_and_filename(content, varname, bryan_bucket=False):
+    """
+    Correct the compressor type as it comes out of Kerchunk (>=0.2.4; pinned).
+    Also correct file name as Kerchnk now prefixes it with "s3://"
+    and for special buckets like Bryan's bnl the correct file is bnl/file.nc
+    not s3://bnl/file.nc
+    """
+    new_content = content.copy()
+
+    # prelimniary assembly
+    try:
+        new_zarray =  ujson.loads(new_content['refs'][f"{varname}/.zarray"])
+        group = False
+    except KeyError:
+        new_zarray =  ujson.loads(new_content['refs'][f"{varname} /{varname}/.zarray"])
+        group = True
+
+    # re-add the correct compressor if it's in the "filters" list
+    if new_zarray["compressor"] is None and new_zarray["filters"]:
+        for zfilter in new_zarray["filters"]:
+            if zfilter["id"] == "zlib":
+                new_zarray["compressor"] = zfilter
+                new_zarray["filters"].remove(zfilter)
+
+        if not group:
+            new_content['refs'][f"{varname}/.zarray"] = ujson.dumps(new_zarray)
+        else:
+            new_content['refs'][f"{varname} /{varname}/.zarray"] = ujson.dumps(new_zarray)
+
+    # FIXME TODO this is an absolute nightmate: the type of bucket on UOR ACES
+    # this is a HACK and it works only with the crazy Bryan S3 bucket "bnl/file.nc"
+    # the problem: filename gets written to JSON as "s3://bnl/file.nc" but Reductionist doesn't
+    # find it since it needs url=bnl/file.nc, with endpoint URL being extracted from the
+    # endpoint_url of storage_options. BAH!
+    if bryan_bucket:
+        for key in new_content['refs'].keys():
+            if varname in key and isinstance(new_content['refs'][key], list) and "s3://" in new_content['refs'][key][0]:
+                new_content['refs'][key][0] = new_content['refs'][key][0].replace("s3://", "")
+
+    return new_content
+
+
 def gen_json(file_url, varname, outf, storage_type, storage_options):
     """Generate a json file that contains the kerchunk-ed data for Zarr."""
     # S3 configuration presets
@@ -24,8 +66,18 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
         with fs.open(file_url, 'rb') as s3file:
             h5chunks = SingleHdf5ToZarr(s3file, file_url,
                                         inline_threshold=0)
+
+            # TODO absolute crap, this needs to go
+            # see comments in _correct_compressor_and_filename
+            bryan_bucket = False
+            if "bnl" in file_url:
+                bryan_bucket = True
+
             with fs2.open(outf, 'wb') as f:
                 content = h5chunks.translate()
+                content = _correct_compressor_and_filename(content,
+                                                           varname,
+                                                           bryan_bucket=bryan_bucket)
                 f.write(ujson.dumps(content).encode())
 
     # S3 passed-in configuration
@@ -36,10 +88,24 @@ def gen_json(file_url, varname, outf, storage_type, storage_options):
         fs = s3fs.S3FileSystem(**storage_options)
         fs2 = fsspec.filesystem('')
         with fs.open(file_url, 'rb') as s3file:
+
+            # Kerchunk wants the correct file name in S3 format
+            if not file_url.startswith("s3://"):
+                file_url = "s3://" + file_url
+
+            # TODO absolute crap: this needs to go
+            # see comments in _correct_compressor_and_filename
+            bryan_bucket = False
+            if "bnl" in file_url:
+                bryan_bucket = True
+
             h5chunks = SingleHdf5ToZarr(s3file, file_url,
                                         inline_threshold=0)
             with fs2.open(outf, 'wb') as f:
                 content = h5chunks.translate()
+                content = _correct_compressor_and_filename(content,
+                                                           varname,
+                                                           bryan_bucket=bryan_bucket)
                 f.write(ujson.dumps(content).encode())
     # not S3
     else:

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - fsspec
   - h5netcdf
   - h5py  # needed by Kerchunk
-  - kerchunk
+  - kerchunk >=0.2.4  # issues with numcodecs in 0.2.3 and API change in 0.2.4
   - netcdf4
   - numcodecs >=0.12  # github.com/valeriupredoi/PyActiveStorage/issues/162
   - numpy !=1.24.3  # severe masking bug

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIREMENTS = {
         'fsspec',
         'h5netcdf',
         'h5py',  # needed by Kerchunk
-        'kerchunk',
+        'kerchunk>=0.2.4',
         'netcdf4',
         'numcodecs>=0.12',  # github/issues/162
         'numpy!=1.24.3',  # severe masking bug


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] All tests pass


`kerchunk=0.2.2` is very old; `kerchunk=0.2.3` had issues with `numcodecs` dependencies`; `kerchunk=0.2.4` is nice and happy and has an optimization we worked on, but it moved the `compressor ` and compressor level inside the `filters` dictionary - this PR fixes that; also, this PR pins Kerchunk to `>=0.2.4` so we don't have to run into old issues, and be able to use the optimization (selection on Dataset or Group to do kerchunking on)
