### PR TITLE
Add git install for osx machines

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,7 @@ jobs:
           use-mamba: true
       - run: conda --version
       - run: python -V
+      - run: conda list
       - run: pip install -e .
       - run: pytest -n 2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - add_git_install_OSX
   schedule:
     - cron: '0 0 * * *'  # nightly
 
@@ -58,5 +59,7 @@ jobs:
           use-mamba: true
       - run: conda --version
       - run: python -V
+      - run: conda list
+      - run: mamba install -c conda-forge git
       - run: pip install -e .
       - run: pytest


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Seen elsewhere, it appears that macOS 14 Github Actions machines now "loose" `git`, even if it is clearly stated that `git` gets installed by default when the container with the OS is loaded and deployed on the node.


## Before you get started


## Checklist

- [ ] This pull request has a descriptive title and labels
- [ ] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] All tests pass
