### PR TITLE
`xfail` a number of tests that connect to `bnl` S3 bucket on CEDA/JASMIN - SOF storage is misfiring very often

### DIFF
--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -151,6 +151,8 @@ def test_compression_and_filters_cmip6_forced_s3_from_local_2():
     assert result == 239.25946044921875
 
 
+# CMIP6_test.nc keeps being unavailable due to BNL bucket unavailable
+@pytest.mark.xfail(reason='JASMIN messing about with SOF.')
 @pytest.mark.skipif(not USE_S3, reason="we need only localhost Reductionist in GA CI")
 @pytest.mark.skipif(REMOTE_RED, reason="we need only localhost Reductionist in GA CI")
 def test_compression_and_filters_cmip6_forced_s3_using_local_Reductionist():

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -27,6 +27,9 @@ storage_options_paramlist = [
 # otherwise, bucket is extracted automatically from full file uri
 S3_BUCKET = "bnl"
 
+
+# CMIP6_test.nc keeps being unavailable due to BNL bucket unavailable
+@pytest.mark.xfail(reason='JASMIN messing about with SOF.')
 @pytest.mark.parametrize("storage_options, active_storage_url", storage_options_paramlist)
 def test_compression_and_filters_cmip6_data(storage_options, active_storage_url):
     """

--- a/tests/test_compression_remote_reductionist.py
+++ b/tests/test_compression_remote_reductionist.py
@@ -75,6 +75,8 @@ def test_compression_and_filters_cmip6_data(storage_options, active_storage_url)
         assert result == 239.25946044921875
 
 
+# CMIP6_test.nc keeps being unavailable due to BNL bucket unavailable
+@pytest.mark.xfail(reason='JASMIN messing about with SOF.')
 @pytest.mark.parametrize("storage_options, active_storage_url", storage_options_paramlist)
 def test_compression_and_filters_cmip6_forced_s3_from_local(storage_options, active_storage_url):
     """
@@ -108,6 +110,8 @@ def test_compression_and_filters_cmip6_forced_s3_from_local(storage_options, act
     # assert result == 239.25946044921875
 
 
+# CMIP6_test.nc keeps being unavailable due to BNL bucket unavailable
+@pytest.mark.xfail(reason='JASMIN messing about with SOF.')
 def test_compression_and_filters_cmip6_forced_s3_from_local_2():
     """
     Test use of datasets with compression and filters applied for a real


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->


[Regular tests](https://github.com/valeriupredoi/PyActiveStorage/actions/runs/9629449388) and [S3/Minio Tests](https://github.com/valeriupredoi/PyActiveStorage/actions/runs/9629577237) both fail to find data on `bnl` bucket on CEDA/JASMIN SOF - which is misfiring very often; I am `xfailing` the three tests that connect there for now. @bnlawrence we really ought to find a more stable/permanent solution to CEDA's S3 storage that keeps crashing.

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- ~[ ] Unit tests have been added (if codecov test fails)~
- ~[ ] Any changed dependencies have been added or removed correctly (if need be)~
- [x] All tests pass
