### PR TITLE
Temporary removal of dependencies used to build sphinx documentation and add `requests` as direct dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - numcodecs >=0.12  # github.com/valeriupredoi/PyActiveStorage/issues/162
   - numpy !=1.24.3  # severe masking bug
   - pip !=21.3
+  - requests
   - s3fs >=2024.2.0  # loose s3fs deps leading to old aiobotocore for <2024.2.0
   # pin Zarr to avoid using old KVStore interface
   # see github.com/zarr-developers/zarr-python/issues/1362

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pytest-metadata >=1.5.1
   - pytest-xdist
   # Python packages needed for building docs
-  - autodocsumm >=0.2.2
-  - sphinx >=5
-  - sphinx_rtd_theme
+  # re-add when we deploy the docs
+  # - autodocsumm >=0.2.2
+  # - sphinx >=5
+  # - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,10 @@ REQUIREMENTS = {
         'pytest-metadata>=1.5.1',
         'pytest-xdist',
         # for documentation
-        'autodocsumm',
-        'sphinx>=5',
-        'sphinx_rtd_theme',
+        # re-add when we deploy the docs
+        # 'autodocsumm',
+        # 'sphinx>=5',
+        # 'sphinx_rtd_theme',
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIREMENTS = {
         'netcdf4',
         'numcodecs>=0.12',  # github/issues/162
         'numpy!=1.24.3',  # severe masking bug
+        'requests',
         's3fs>=2024.2.0',  # see environment.yml for pin reason
         # pin Zarr to use new FSStore instead of KVStore
         'zarr>=2.13.3', # github.com/zarr-developers/zarr-python/issues/1362


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #195 

A good call raised by @davidhassell to (temporarily) remove unused dependencies mea\nt for sphinx build docs. We can always re-add them when we deploy and autobuild docs on e.g. ReadTheDocs.

## Before you get started

- [x] [☝ Create an issue](https://github.com/valeriupredoi/PyActiveStorage/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- ~[ ] Unit tests have been added (if codecov test fails)~
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] All tests pass
